### PR TITLE
Enable encrypted keystore backup

### DIFF
--- a/FreeOTP/KeychainStore.swift
+++ b/FreeOTP/KeychainStore.swift
@@ -52,14 +52,14 @@ open class KeychainStore<T: KeychainStorable> {
         if locked {
             let sac = SecAccessControlCreateWithFlags(
                 kCFAllocatorDefault,
-                kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                kSecAttrAccessibleWhenUnlocked,
                 .userPresence,
                 nil
             )
 
             add[kSecAttrAccessControl as String] = sac
         } else {
-            add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
         }
 
         return SecItemAdd(add as CFDictionary, nil) == errSecSuccess


### PR DESCRIPTION
This sets the keychain item access control to allow *encrypted* only backup and restore functionality of tokens in the keystore.

By default, iOS backups are taken unencrypted and will not include FreeOTP token data. 

- for iTunes backups, you must check the box to encrypt backup in the iTunes backup administration page
- for iCloud backups, you must set 'Keychain' to **On** in the "Apps Using iCloud" menu of iCloud settings