### PR TITLE
Fix crash when clicking 'Share'

### DIFF
--- a/FreeOTP/Info.plist
+++ b/FreeOTP/Info.plist
@@ -37,6 +37,14 @@
 	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>$(PRODUCT_NAME) requests access to Bluetooth to share token codes</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>$(PRODUCT_NAME) requests access to Bluetooth to share token codes</string>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) requires access to the camera to scan a QR code for token import</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>$(PRODUCT_NAME) requests access to the Photo Library to select token key image</string>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch</string>
 	<key>UIMainStoryboardFile</key>
@@ -48,11 +56,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>$(PRODUCT_NAME) requires access to the camera to scan a QR code for token import</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>$(PRODUCT_NAME) requests access to the Photo Library to select token key image</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>$(PRODUCT_NAME) requests access to Bluetooth to share token codes</string>
 </dict>
 </plist>


### PR DESCRIPTION
This addition to Info.plist is required due to iOS 10+ privacy control enforcement.

https://iosdevcenters.blogspot.com/2016/09/infoplist-privacy-settings-in-ios-10.html