### PR TITLE
Fix opening an otpauth URL with FreeOTP closed

### DIFF
--- a/FreeOTP/ScanViewController.swift
+++ b/FreeOTP/ScanViewController.swift
@@ -93,7 +93,13 @@ class ScanViewController : UIViewController, AVCaptureMetadataOutputObjectsDeleg
             return
         }
 
+        orient(UIApplication.shared.statusBarOrientation)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        enabled = true
         if urlSent {
+            urlSent = false
             if !pushNextViewController(urlc) {
                 TokenStore().add(urlc)
                 switch UIDevice.current.userInterfaceIdiom {
@@ -107,11 +113,6 @@ class ScanViewController : UIViewController, AVCaptureMetadataOutputObjectsDeleg
         } else {
             preview.session!.startRunning()
         }
-        orient(UIApplication.shared.statusBarOrientation)
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        enabled = true
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
Ensures that the navigation heirachy is ready before pushing
controllers onto the stack, allowing correct presentation of the Scan
Token Wizard.