### PR TITLE
Add Support for FaceID unlocking

### DIFF
--- a/FreeOTP/Info.plist
+++ b/FreeOTP/Info.plist
@@ -49,6 +49,8 @@
 	<string>Launch</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Biometric support for locked tokens</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Authentication flag is already set for Token Keychain items, so we only need this `Info.plist` addition to enable FaceID support.

https://developer.apple.com/documentation/localauthentication/accessing_keychain_items_with_face_id_or_touch_id

Tested on iPhone 11 iOS 13.5