### PR TITLE
Fix crash in performBatchUpdates after rotation

### DIFF
--- a/FreeOTP/TokensViewController.swift
+++ b/FreeOTP/TokensViewController.swift
@@ -138,8 +138,9 @@ class TokensViewController : UICollectionViewController, UICollectionViewDelegat
         }
     }
 
-    override func didRotate(from fromInterfaceOrientation: UIInterfaceOrientation) {
-        collectionView?.performBatchUpdates(nil, completion: nil)
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        collectionView.collectionViewLayout.invalidateLayout()
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {


### PR DESCRIPTION
This should fix a crash based on crash report logs submitted from FreeOTP v2.0, it appears to be only on iOS 12 or lower devices.