### PR TITLE
About Modal Close Button

### DIFF
--- a/FreeOTP/Base.lproj/Main.storyboard
+++ b/FreeOTP/Base.lproj/Main.storyboard
@@ -159,6 +159,14 @@
                                     </textView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="81w-vT-ZSH">
+                                <rect key="frame" x="16" y="20" width="39" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Close"/>
+                                <connections>
+                                    <segue destination="9Pi-UR-R9Z" kind="unwind" unwindAction="unwindToTokens:" id="7WF-8G-4jf"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
@@ -174,6 +182,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="psb-Qx-D8w" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="9Pi-UR-R9Z" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="517.60000000000002" y="379.16041979010498"/>
         </scene>


### PR DESCRIPTION
Adds a close button to the about modal. This should decrease user confusion and also prevent issues on older iOS devices that do not support swiping down. Resolves freeotp/freeotp-ios#182 and resolves freeotp/freeotp-ios#205.  

https://user-images.githubusercontent.com/10404365/125182732-22eadb80-e1d6-11eb-8036-0535591dcd3b.mp4

