### PR TITLE
Support Deselecting Tokens

### DIFF
--- a/FreeOTP/TokensViewController.swift
+++ b/FreeOTP/TokensViewController.swift
@@ -271,6 +271,18 @@ class TokensViewController : UICollectionViewController, UICollectionViewDelegat
             }
         }
     }
+    
+    @objc func handleTap(gestureRecognizer: UITapGestureRecognizer) {
+        // Neccessary to prevent gesture recognizer from overriding default behavior,
+        // such as UICollectionView's `didSelectItemAt` delegate method.
+        gestureRecognizer.cancelsTouchesInView = false
+
+        // Deselect tokens when empty space in collection view is tapped.
+        let tapLocation = gestureRecognizer.location(in: view)
+        if collectionView.indexPathForItem(at: tapLocation) == nil {
+            reloadData()
+        }
+    }
 
     @IBAction func unwindToTokens(_ sender: UIStoryboardSegue) {
         reloadData()
@@ -310,6 +322,10 @@ class TokensViewController : UICollectionViewController, UICollectionViewDelegat
 
         let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(self.handleSwipe))
         collectionView?.addGestureRecognizer(swipeGesture)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+        tapGesture.numberOfTapsRequired = 1
+        collectionView?.addGestureRecognizer(tapGesture)
         
         // show the search bar only if there are items to be searched
         showSearchButton()


### PR DESCRIPTION
Currently it’s not possible to deselect a token once it’s been selected. This means that once you select a token, you must wait for it to dismiss itself when the timer is up, or force quit the application and re-open it to hide the token or use the share button.

This pull request adds the ability to tap on an empty area of the collection view to deselect tokens. I tested to ensure that no other behavior was changed, and existing gestures (tapping to view a token, swiping to delete, and dragging and dropping to rearrange) still work. It also animates as expected and only activates if the empty space of the collection view is tapped, not when the navigation bar or other elements are tapped so as to be intuitive for users.

https://user-images.githubusercontent.com/10404365/126008585-826e111a-0ffb-4723-bc12-d1e90c6fd250.mp4