### PR TITLE
Fixed truncation Close button title on the About screen

### DIFF
--- a/FreeOTP/Base.lproj/Main.storyboard
+++ b/FreeOTP/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="1u3-cr-3fz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="1u3-cr-3fz">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -83,7 +83,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="shareRow" id="Mf6-nW-1Zf">
-                                <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="49.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Mf6-nW-1Zf" id="KeR-bk-SlQ">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -159,9 +159,11 @@
                                     </textView>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="81w-vT-ZSH">
-                                <rect key="frame" x="16" y="20" width="39" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="81w-vT-ZSH">
+                                <rect key="frame" x="16" y="20" width="50" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="50" id="kMP-iw-eAD"/>
+                                </constraints>
                                 <state key="normal" title="Close"/>
                                 <connections>
                                     <segue destination="9Pi-UR-R9Z" kind="unwind" unwindAction="unwindToTokens:" id="7WF-8G-4jf"/>
@@ -171,6 +173,8 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="MoQ-xR-dvk" firstAttribute="top" secondItem="XvS-Wt-gAZ" secondAttribute="bottom" constant="70" id="S2t-a6-QpP"/>
+                            <constraint firstItem="81w-vT-ZSH" firstAttribute="top" secondItem="XvS-Wt-gAZ" secondAttribute="bottom" constant="20" id="Xb6-ib-IOm"/>
+                            <constraint firstItem="81w-vT-ZSH" firstAttribute="leading" secondItem="HVU-uU-wyH" secondAttribute="leading" constant="16" id="p6h-eT-0cN"/>
                             <constraint firstAttribute="trailing" secondItem="MoQ-xR-dvk" secondAttribute="trailing" constant="16" id="q05-yP-4WX"/>
                             <constraint firstItem="MoQ-xR-dvk" firstAttribute="leading" secondItem="HVU-uU-wyH" secondAttribute="leading" constant="16" id="r4s-5V-scv"/>
                             <constraint firstItem="nrK-d1-N1Y" firstAttribute="top" secondItem="MoQ-xR-dvk" secondAttribute="bottom" constant="160.5" id="spY-22-6vQ"/>


### PR DESCRIPTION
### I found an issue with the truncated Close button title on the About screen on my iPhone 12 mini - the button looks like an ellipsis.
![IMG_3435](https://user-images.githubusercontent.com/52785704/155884968-2f945fb2-611e-4de6-b45b-e0e47ca05e0d.PNG)

### Here is the fix result
![IMG_3436](https://user-images.githubusercontent.com/52785704/155885014-82051d6e-2b62-4f84-bac5-9bb19f8624d1.PNG)

