### PR TITLE
Changed `About` Section Date to be dynamic

### DIFF
--- a/FreeOTP/AboutViewController.swift
+++ b/FreeOTP/AboutViewController.swift
@@ -45,16 +45,17 @@ class AboutViewController : UIViewController, UITextViewDelegate {
     @IBOutlet weak var aboutTextView: UITextView!
 
     let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+    let currentyear = Calendar.current.component(.year, from: Date())
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         versionLabel.text = "FreeOTP \(appVersion)"
         versionLabel.font = UIFont.boldSystemFont(ofSize: 28.0)
-
+        
         aboutTextView.delegate = self
-        aboutTextView.text = """
-        2013-2020 - Red Hat, Inc., et al.
+        aboutTextView.text =  """
+        2013-\(currentyear) - Red Hat, Inc., et al.
 
         FreeOTP is licensed under Apache 2.0
 


### PR DESCRIPTION
- `End` date of the About section will always be set as the current year dynamically

**Before**
![IMG_5D83500A6FAA-1](https://user-images.githubusercontent.com/2150634/170338826-5002bd4f-d443-429b-9b7c-514811d041cd.jpeg)

**After**
![IMG_89E7B8E45840-1](https://user-images.githubusercontent.com/2150634/170338859-ecebe3d8-f3dc-4026-9adf-6305f15a6bcb.jpeg)


Signed off by Mulili Nzuki<mulili.nzuki@gmail.com>