### PR TITLE
Remove abnormal unicode Line Separator U+2028 char

### DIFF
--- a/FreeOTP/Base.lproj/Main.storyboard
+++ b/FreeOTP/Base.lproj/Main.storyboard
@@ -504,7 +504,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="pQa-Lk-vD0">
                                 <rect key="frame" x="64" y="111" width="246.5" height="209"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your token provider has  not configured the issuer  field, please enter the name  of the issuer" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rk9-rR-33m">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your token provider has not configured the issuer field, please enter the name of the issuer" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rk9-rR-33m">
                                         <rect key="frame" x="0.0" y="0.0" width="246.5" height="95.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <nil key="textColor"/>


### PR DESCRIPTION
Added in FreeOTP/Base.lproj/Main.storyboard in the PR/commit below:
- https://github.com/freeotp/freeotp-ios/pull/144
- 36278532d89ec83fff1eb80e5e8a9146cb188eed

Vim screenshot:

![image](https://github.com/freeotp/freeotp-ios/assets/3691490/6606dbea-1237-434e-a26f-408325891678)

VSCode warning when opening this file:

![image](https://github.com/freeotp/freeotp-ios/assets/3691490/02a01581-cc1e-412d-957a-17f8bd794125)

Difference from the view of the git command line interface:

```diff
diff --git a/FreeOTP/Base.lproj/Main.storyboard b/FreeOTP/Base.lproj/Main.storyboard
index 68c8cc0..f573f35 100644
--- a/FreeOTP/Base.lproj/Main.storyboard
+++ b/FreeOTP/Base.lproj/Main.storyboard
@@ -504,7 +504,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="pQa-Lk-vD0">
                                 <rect key="frame" x="64" y="111" width="246.5" height="209"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your token provider has <U+2028>not configured the issuer <U+2028>field, please enter the name <U+2028>of the issuer" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rk9-rR-33m">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your token provider has not configured the issuer field, please enter the name of the issuer" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rk9-rR-33m">
                                         <rect key="frame" x="0.0" y="0.0" width="246.5" height="95.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <nil key="textColor"/>
```

Unicode Line Separator U+2028 reference:
- https://unicodeplus.com/U+2028
- https://www.compart.com/en/unicode/U+2028