### PR TITLE
Remove invalid Travis CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/freeotp/freeotp-ios.svg?branch=master)](https://travis-ci.org/freeotp/freeotp-ios)
-
 # FreeOTP
 
 [FreeOTP](https://freeotp.github.io/) is a two-factor authentication application for systems


### PR DESCRIPTION
As travis-ci.org was dropped for a while, and there even didn't seem to be an Travis CI config existed. The badge has no reason to be placed in the README.md.