### PR TITLE
Fix missing issuer in QR URI causing duplicate tokens

### DIFF
--- a/FreeOTP/URILabelViewController.swift
+++ b/FreeOTP/URILabelViewController.swift
@@ -23,9 +23,9 @@ class URILabelViewController: UIViewController, UITextFieldDelegate {
     @IBAction func nextClicked(_ sender: UIBarButtonItem) {
         if issuerTextField.text == "" {
             presentAlert(title: "Issuer missing", message: "It is recommended to provide a value for the Issuer field to take advantage of FreeOTP Icon features. Do you really want to use an empty issuer value?", actionTitleAccept: "Use empty issuer", actionTitleCancel: "Cancel")
+        } else {
+            submitForm()
         }
-
-        submitForm()
     }
 
     // MARK: - UITextFieldDelegate


### PR DESCRIPTION
Hello,

Resolves: #379 

### Issue analysis:
Assuming the issuer is missing in the URI. The issuer prompt view will be pushed into the secne. And when the user clicks `next` The below code will warn the user and process the form.
![image](https://github.com/user-attachments/assets/16b115e9-3ef4-4314-adfc-5b33feea49ad)
Here, we can see if the user clicks "use empty issuer" the app will process the form. 
![image](https://github.com/user-attachments/assets/b482a3d5-5b13-484e-9623-ab4941a209df)

The form is processed twice (Could be more if the user clicks cancel and repeat) according to the logic above.

### The fix is simple:
Now `submitForm` is called only in two cases. One if the issuer is entered or if the user `use empty issuer` where submitForm is called inside the function.

![image](https://github.com/user-attachments/assets/7d051764-9358-4ba2-b24d-01da5ee2a4a6)
